### PR TITLE
Makefile: Cockpit lib updated *2po scripts to be in python

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,10 +59,10 @@ po/$(PACKAGE_NAME).js.pot:
 		sed '/^#/ s/, c-format//' > $@
 
 po/$(PACKAGE_NAME).html.pot: $(NODE_MODULES_TEST) $(COCKPIT_REPO_STAMP)
-	pkg/lib/html2po.js -o $@ $$(find src -name '*.html')
+	pkg/lib/html2po -o $@ $$(find src -name '*.html')
 
 po/$(PACKAGE_NAME).manifest.pot: $(NODE_MODULES_TEST) $(COCKPIT_REPO_STAMP)
-	pkg/lib/manifest2po.js src/manifest.json -o $@
+	pkg/lib/manifest2po src/manifest.json -o $@
 
 po/$(PACKAGE_NAME).metainfo.pot: $(APPSTREAMFILE)
 	xgettext --default-domain=$(PACKAGE_NAME) --output=$@ $<


### PR DESCRIPTION
This was updated in https://github.com/cockpit-project/cockpit/commit/54f87df7b7b5428c66bae8c1b91f30963c8bdb45 and https://github.com/cockpit-project/cockpit/commit/3288a3e2d21ae1bf674875ba6c9f9daf0e93c3fc