### PR TITLE
Fix: Only trigger setFormFields on load in settings_form

### DIFF
--- a/src/components/settings_form.tsx
+++ b/src/components/settings_form.tsx
@@ -49,7 +49,7 @@ const SettingsForm = ({ formData, setFormData }: Props) => {
 
     useEffect(() => {
         setFormFields();
-    }, [setFormData, setFormFields]);
+    }, []);
 
     const submit = useCallback(() => {
         setSubmitting(true);


### PR DESCRIPTION
This fixes a bug where if the system is already registered, and then you try to edit the settings (proxy url and language) it's uneditable